### PR TITLE
replace code_level with nchar

### DIFF
--- a/R/create_benchmark_loanbook.R
+++ b/R/create_benchmark_loanbook.R
@@ -36,7 +36,7 @@ create_benchmark_loanbook <- function(data,
   benchmark_sectors <- r2dii.data::nace_classification %>%
     dplyr::filter(.data$borderline == FALSE) %>%
     dplyr::group_by(.data$sector) %>%
-    dplyr::slice_max(.data$code_level, n = 1) %>%
+    dplyr::slice_max(nchar(.data$code), n = 1) %>%
     dplyr::slice_head(n = 1) %>%
     dplyr::ungroup() %>%
     dplyr::select("sector", "code")


### PR DESCRIPTION
closes #18 

- replaces `max(code_level)` with `max(nchar(code))` to identify sector codes at the most granular level, as `code_level` was deprecated from `r2dii.data`